### PR TITLE
Update projection matrix on move

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -98,7 +98,7 @@ declare class MapScene {
     private readonly _world;
     private readonly _composer;
     private readonly _renderPass;
-    private readonly _customOutPass;
+    private readonly _outputPass;
     private _event;
     constructor(map: IMap, options?: Partial<IMapSceneOptions>);
     get map(): IMap;
@@ -110,7 +110,7 @@ declare class MapScene {
     get renderer(): WebGLRenderer;
     get composer(): EffectComposer | undefined;
     get renderPass(): RenderPass | undefined;
-    get customOutPass(): OutputPass | undefined;
+    get outputPass(): OutputPass | undefined;
     /**
      *
      * @private

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -52,6 +52,8 @@ interface IMapSceneOptions {
      * for maximum performance and stability.
      */
     enablePostProcessing: boolean;
+    /** Wheter to synchronize the camera on move. */
+    updateProjectionOnMove: boolean;
 }
 /**
  * Frame state information passed to event listeners
@@ -225,6 +227,11 @@ declare class MapScene {
      * @returns {MapScene}
      */
     removePass(pass: Pass): MapScene;
+    /**
+     * Gets the option, if the projection matrix should be updated during camera synchronion when moved.
+     * @returns {boolean}
+     */
+    updateProjectionOnMove(): boolean;
 }
 
 declare class SceneTransform {

--- a/src/modules/camera/CameraSync.ts
+++ b/src/modules/camera/CameraSync.ts
@@ -16,8 +16,9 @@ class CameraSync {
   private _camera: PerspectiveCamera
   private _translateCenter: Matrix4
   private readonly _worldSizeRatio: number
+  private readonly _updateProjMatrixOnMove: boolean
 
-  constructor(map: IMap, world: Group, camera: PerspectiveCamera) {
+  constructor(map: IMap, world: Group, camera: PerspectiveCamera, updateOnMove?: boolean) {
     this._map = map
     this._world = world
     this._camera = camera
@@ -27,8 +28,9 @@ class CameraSync {
       0
     )
     this._worldSizeRatio = TILE_SIZE / WORLD_SIZE
+    this._updateProjMatrixOnMove = updateOnMove ?? false
     this._map.on('move', () => {
-      this.syncCamera(false)
+      this.syncCamera(this._updateProjMatrixOnMove)
     })
     this._map.on('resize', () => {
       this.syncCamera(true)

--- a/src/modules/layer/ThreeLayer.ts
+++ b/src/modules/layer/ThreeLayer.ts
@@ -12,7 +12,8 @@ class ThreeLayer {
     this._cameraSync = new CameraSync(
       this._mapScene.map,
       this._mapScene.world,
-      this._mapScene.camera
+      this._mapScene.camera,
+      this._mapScene.updateProjectionOnMove()
     )
   }
 

--- a/src/modules/scene/MapScene.ts
+++ b/src/modules/scene/MapScene.ts
@@ -25,6 +25,7 @@ const DEF_OPTS = {
   preserveDrawingBuffer: false,
   renderLoop: null,
   enablePostProcessing: false,
+  updateProjectionOnMove: false,
 }
 
 const DEF_LAYER_ID = 'map_scene_layer'
@@ -73,7 +74,9 @@ interface IMapSceneOptions {
    * When disabled, Three.js renders directly into the shared MapLibre canvas
    * for maximum performance and stability.
    */
-  enablePostProcessing: boolean
+  enablePostProcessing: boolean,
+  /** Wheter to synchronize the camera on move. */
+  updateProjectionOnMove: boolean,
 }
 
 /**
@@ -560,5 +563,13 @@ export class MapScene {
     }
     this._composer.removePass(pass)
     return this
+  }
+
+  /**
+   * Gets the option, if the projection matrix should be updated during camera synchronion when moved.
+   * @returns {boolean}
+   */
+  updateProjectionOnMove(): boolean {
+    return this._options.updateProjectionOnMove;
   }
 }


### PR DESCRIPTION
This PR introduce the feature to set, whether the projection matrix should be update, when the map is moved.

You can set this with `updateProjectionOnMove` when you create the `MapScene`:
```
  const mapScene = new MapScene(map as any, {updateProjectionOnMove: true});
```

This fixes #11 

Let me know, if I should adjust something, as you prefer.